### PR TITLE
Changed error -> info logging in some of the opus log statements

### DIFF
--- a/discord/opus.py
+++ b/discord/opus.py
@@ -127,7 +127,7 @@ signal_ctl: SignalCtl = {
 
 def _err_lt(result: int, func: Callable, args: list) -> int:
     if result < OK:
-        _log.info("error has happened in %s", func.__name__)
+        _log.debug("error has happened in %s", func.__name__)
         raise OpusError(result)
     return result
 
@@ -135,7 +135,7 @@ def _err_lt(result: int, func: Callable, args: list) -> int:
 def _err_ne(result: T, func: Callable, args: list) -> T:
     ret = args[-1]._obj
     if ret.value != OK:
-        _log.info("error has happened in %s", func.__name__)
+        _log.debug("error has happened in %s", func.__name__)
         raise OpusError(ret.value)
     return result
 
@@ -339,7 +339,7 @@ class OpusError(DiscordException):
     def __init__(self, code: int):
         self.code: int = code
         msg = _lib.opus_strerror(self.code).decode("utf-8")
-        _log.info('"%s" has happened', msg)
+        _log.debug('"%s" has happened', msg)
         super().__init__(msg)
 
 


### PR DESCRIPTION
Changed error logging in some of the opus logging to log to debug because it was drastically bloating the info logs