### PR TITLE
Crypto error try-catch

### DIFF
--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -908,11 +908,12 @@ class VoiceClient(VoiceProtocol):
             except OSError:
                 self.stop_recording()
                 continue
+
+            try:
+                self.unpack_audio(data)
             except (nacl.exceptions.CryptoError, IndexError) as e:
                 _log.error("An error occurred while decrypting: %s - %s", type(e).__name__, e)
                 continue
-
-            self.unpack_audio(data)
 
         self.stopping_time = time.perf_counter()
         self.sink.cleanup()


### PR DESCRIPTION
Re-added try-catch around unpack_audio so that the connection isn't killed if there is one bad piece of data.
There is a bug where bad data comes in temporarily (esp. on start connection or reconnection)